### PR TITLE
rebuild for 3.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,7 +88,7 @@ test:
     - if not exist %PREFIX%\Library\lib\girepository-1.0.lib exit 1  # [win]
 
 about:
-  home: https://wiki.gnome.org/action/show/Projects/GObjectIntrospection
+  home: https://gi.readthedocs.io/
   license: LGPL-2.0-or-later
   license_family: LGPL
   license_file:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - handle_visual_studio_forceinline.patch
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   skip: true  # [win and vc<14]
   ignore_run_exports:
@@ -37,7 +37,7 @@ requirements:
   build:
     - python
     # run-dep as a workaround for now; upstream package still imports from distutils
-    - setuptools  # [py>311]
+    - setuptools <74  # [py>311]
     - {{ posix }}bison
     - {{ posix }}flex
     - {{ posix }}patch
@@ -59,23 +59,21 @@ requirements:
     - libffi {{ libffi }}
     - pthread-stubs 0.3
     - zlib {{ zlib }} # [win]
-    - setuptools
+    - setuptools <74
   run:
     - python
     # through run_exports
     - libffi
     - libglib
     # run-dep as a workaround for now; upstream package still imports from distutils
-    - setuptools  # [py>311]
+    # imports distutils.msvccompiler which has been removed on recent setuptools
+    - setuptools <74  # [py>311]
 
 test:
   requires:
     - python  # [win]
     - pkg-config
-    - conda-build  # [not win]
   commands:
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
-    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
     - g-ir-scanner --help  # [not win]
     - python "%PREFIX%\\Library\\bin\\g-ir-scanner" --help  # [win]
     - g-ir-compiler --help
@@ -88,6 +86,7 @@ test:
     - test -f $PREFIX/lib/libgirepository-1.0${SHLIB_EXT}  # [not win]
     - if not exist %PREFIX%\Library\bin\girepository-1.0-1.dll exit 1  # [win]
     - if not exist %PREFIX%\Library\lib\girepository-1.0.lib exit 1  # [win]
+
 about:
   home: https://wiki.gnome.org/action/show/Projects/GObjectIntrospection
   license: LGPL-2.0-or-later


### PR DESCRIPTION
rebuild for 3.13.
- restricts setuptools version due to recent setuptools having distutils features removed.
- do not depend on conda-build for tests as it is not yet available for 3.13.